### PR TITLE
Update the portfile to remove debug/share file for hyperscan

### DIFF
--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -26,5 +26,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**
The `hyperscan` library cannot be installed on my Mac (macOS 10.15) with the following error below. I am on vcpkg master branch commit `101452334cf0f1ba5329fd07f8b8f37f81fa2fc1`. It looks like the `debug/share` file should be removed so that hyperscan post-install validation can pass, and I managed to pass the post-install validation check by following the instructions given in the error message.
```
vcpkg install hyperscan
The following packages will be built and installed:
    hyperscan[core]:x64-osx
Starting package 1/1: hyperscan:x64-osx
Building package hyperscan[core]:x64-osx...
-- Using cached ~/dev/tools/vcpkg/downloads/intel-hyperscan-v5.1.0.tar.gz
-- Using source at ~/dev/tools/vcpkg/buildtrees/hyperscan/src/v5.1.0-e80f138a71
-- Configuring x64-osx-dbg
-- Configuring x64-osx-rel
-- Building x64-osx-dbg
-- Building x64-osx-rel
-- Installing: ~/dev/tools/vcpkg/packages/hyperscan_x64-osx/share/hyperscan/copyright
-- Performing post-build validation
/debug/share should not exist. Please reorganize any important files, then use
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
Found 1 error(s). Please correct the portfile:
    ~/dev/tools/vcpkg/ports/hyperscan/portfile.cmake
-- Performing post-build validation done
Error: Building package hyperscan:x64-osx failed with: POST_BUILD_CHECKS_FAILED
Please ensure you're using the latest portfiles with `.\vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: hyperscan:x64-osx
  Vcpkg version: 2019.09.12-unknownhash
```

- What does your PR fix? Fixes issue #
NA

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
